### PR TITLE
Use UTF-8 encoding instead of Latin-1. Closes #8

### DIFF
--- a/src/Checker.cpp
+++ b/src/Checker.cpp
@@ -25,6 +25,7 @@
 #include <QLocale>
 #include <QMenu>
 #include <QTranslator>
+#include <QtDebug>
 
 static void dict_describe_cb(const char* const lang_tag,
 							 const char* const /*provider_name*/,
@@ -107,7 +108,7 @@ bool Checker::setLanguageInternal(const QString &lang)
 	if(m_lang.isEmpty()){
 		m_lang = QLocale::system().name();
 		if(m_lang.toLower() == "c" || m_lang.isEmpty()){
-			qWarning("Cannot use system locale %s", m_lang.toLatin1().data());
+			qWarning() << "Cannot use system locale " << m_lang;
 			m_lang = QString::null;
 			return false;
 		}
@@ -117,7 +118,7 @@ bool Checker::setLanguageInternal(const QString &lang)
 	try {
 		m_speller = get_enchant_broker()->request_dict(m_lang.toStdString());
 	} catch(enchant::Exception& e) {
-		qWarning("Failed to load dictionary: %s", e.what());
+		qWarning() << "Failed to load dictionary: " << e.what();
 		m_lang = QString::null;
 		return false;
 	}

--- a/src/Codetable.cpp
+++ b/src/Codetable.cpp
@@ -21,6 +21,7 @@
 #include <QDir>
 #include <QFile>
 #include <QXmlStreamReader>
+#include <QtDebug>
 #include <libintl.h>
 
 #define ISO_639_DOMAIN  "iso_639"
@@ -77,7 +78,7 @@ void Codetable::parseIso639Elements(const QXmlStreamReader &xml, QMap<QString, Q
 		QString name = xml.attributes().value("name").toString();
 		QString code = xml.attributes().value("iso_639_1_code").toString();
 		if(!name.isEmpty() && !code.isEmpty()){
-			name = QString::fromUtf8(dgettext(ISO_639_DOMAIN, name.toLatin1().data()));
+			name = QString::fromUtf8(dgettext(ISO_639_DOMAIN, name.toUtf8().constData()));
 			table.insert(code, name);
 		}
 	}
@@ -89,7 +90,7 @@ void Codetable::parseIso3166Elements(const QXmlStreamReader &xml, QMap<QString, 
 		QString name = xml.attributes().value("name").toString();
 		QString code = xml.attributes().value("alpha_2_code").toString();
 		if(!name.isEmpty() && !code.isEmpty()){
-			name = QString::fromUtf8(dgettext(ISO_3166_DOMAIN, name.toLatin1().data()));;
+			name = QString::fromUtf8(dgettext(ISO_3166_DOMAIN, name.toUtf8().constData()));
 			table.insert(code, name);
 		}
 	}
@@ -100,7 +101,7 @@ void Codetable::parse(const QDir& dataDir, const QString& basename, const parser
 	QString filename = QDir(QDir(dataDir.filePath("xml")).filePath("iso-codes")).absoluteFilePath(basename);
 	QFile file(filename);
 	if(!file.open(QIODevice::ReadOnly)){
-		qWarning("Failed to open %s for reading", file.fileName().toLatin1().data());
+		qWarning() << "Failed to open " << file.fileName() << " for reading";
 		return;
 	}
 


### PR DESCRIPTION
Use UTF-8 encoding instead of Latin-1.

Closes https://github.com/manisandro/qtspell/issues/8

This is related to submitting my flatpak package to the Flathub repository.
https://github.com/manisandro/gImageReader/issues/396
https://github.com/flathub/flathub/pull/810